### PR TITLE
Fix issue with incompatible python packages versions (boto and dateutil)

### DIFF
--- a/docker/dockerfiles/rl_coach/Dockerfile
+++ b/docker/dockerfiles/rl_coach/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir /robo
 RUN mkdir /robo/container
 
 # install dependencies
-RUN pip install -U sagemaker-python-sdk/ awscli ipython pandas "urllib3==1.22" "pyyaml==3.13"
+RUN pip install -U sagemaker-python-sdk/ awscli ipython pandas "urllib3==1.22" "pyyaml==3.13" "python-dateutil==2.8.0"
 
 # set command
 CMD (cd rl_coach; ipython rl_deepracer_coach_robomaker.py)


### PR DESCRIPTION
After running init.sh:  

`ERROR: botocore 1.13.9 has requirement python-dateutil<2.8.1,>=2.1; python_version >= "2.7", but you'll have python-dateutil 2.8.1 which is incompatible.`