### PR TITLE
Fix `rl_coach` Docker volume path to work on Mac OSX

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     - '//var/run/docker.sock:/var/run/docker.sock'
     - '../deepracer/sagemaker-python-sdk:/deepracer/sagemaker-python-sdk'
     - '../deepracer/rl_coach:/deepracer/rl_coach'
-    - '/robo/container:/robo/container'
+    - './volumes/robo/container:/robo/container'
     depends_on:
     - minio
   robomaker:


### PR DESCRIPTION
Relates to: https://github.com/alexschultz/deepracer-for-dummies/issues/29

Root level folders have restricted access on Mac OSX, which might be one reason why this didn't work before.  This change makes the `rl_coach` target consistent with the `robomaker` target.

TESTING

Before fix:
```
$ ./start.sh 
Creating minio ... done
Creating rl_coach ... error

ERROR: for rl_coach  Cannot start service rl_coach: b'Mounts denied: \r\nThe path /robo/container\r\nis not shared from OS X and is not known to Docker.\r\nYou can configure shared paths from Docker -> Preferences... -> File Sharing.\r\nSee https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.\r\n.'

ERROR: for rl_coach  Cannot start service rl_coach: b'Mounts denied: \r\nThe path /robo/container\r\nis not shared from OS X and is not known to Docker.\r\nYou can configure shared paths from Docker -> Preferences... -> File Sharing.\r\nSee https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.\r\n.'
ERROR: Encountered errors while bringing up the project.
waiting for containers to start up...
```
After fix:
```
$ ./start.sh 
Creating minio ... done
Creating rl_coach ... done
Creating robomaker ... done
waiting for containers to start up...
```