### PR TITLE
Make `start.sh` cope when gnome-terminal is missing, e.g. on Mac OSX

### DIFF
--- a/scripts/training/start.sh
+++ b/scripts/training/start.sh
@@ -8,8 +8,24 @@ echo 'waiting for containers to start up...'
 #sleep for 20 seconds to allow the containers to start
 sleep 15
 
-echo 'attempting to pull up sagemaker logs...'
-gnome-terminal -x sh -c "!!; docker logs -f $(docker ps | awk ' /sagemaker/ { print $1 }')"
+if ! [ -x "$(command -v gnome-terminal)" ]; 
+then
+  echo 'Error: skip showing sagemaker logs because gnome-terminal is not installed.  This is normal if you are on a different OS to Ubuntu.'
+else	
+  echo 'attempting to pull up sagemaker logs...'
+  gnome-terminal -x sh -c "!!; docker logs -f $(docker ps | awk ' /sagemaker/ { print $1 }')"
+fi
 
-echo 'attempting to open vnc viewer...'
-gnome-terminal -x sh -c "!!; vncviewer localhost:8080"
+if ! [ -x "$(command -v gnome-terminal)" ]; 
+then
+  if ! [ -x "$(command -v vncviewer)" ]; 
+  then
+    echo 'Error: vncviewer is not present on the PATH.  Make sure you install it and add it to the PATH.'
+  else	
+    echo 'attempting to open vnc viewer...'
+    vncviewer localhost:8080
+  fi
+else	
+  echo 'attempting to open vnc viewer...'
+  gnome-terminal -x sh -c "!!; vncviewer localhost:8080"
+fi


### PR DESCRIPTION
Relates to: https://github.com/alexschultz/deepracer-for-dummies/issues/29

`gnome-terminal` doesn't exist on Mac OSX, so we need to cope without it.  Calling `vncviewer` directly opens it in a new window, so that works fine (even though for me it currently shows an empty environment in RVis).

TESTING

Before fix:
```
$ ./start.sh 
Creating minio ... done
Creating rl_coach ... done
Creating robomaker ... done
waiting for containers to start up...
attempting to pull up sagemaker logs...
./start.sh: line 12: gnome-terminal: command not found
attempting to open vnc viewer...
./start.sh: line 15: gnome-terminal: command not found
```
After fix, with both errors happening:
```
$ ./start.sh
minio is up-to-date
Starting rl_coach ... done
robomaker is up-to-date
waiting for containers to start up...
Error: skip showing sagemaker logs because gnome-terminal is not installed.  This is normal if you are on a different OS to Ubuntu.
Error: vncviewer is not present on the PATH.  Make sure you install it and add it to the PATH.
```
After fix, with `vncviewer` added to the PATH (using `sudo vi /etc/paths`):
```
$ ./start.sh 
minio is up-to-date
Starting rl_coach ... done
robomaker is up-to-date
waiting for containers to start up...
Error: skip showing sagemaker logs because gnome-terminal is not installed.  This is normal if you are on a different OS to Ubuntu.
attempting to open vnc viewer...
```