### PR TITLE
Check for existence of  rl-deepracer-sagemaker before deleting!

### DIFF
--- a/scripts/training/set-last-run-to-pretrained.sh
+++ b/scripts/training/set-last-run-to-pretrained.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+Folder=rl-deepracer-sagemaker
+if [ -d ../../docker/volumes/minio/bucket/rl-deepracer-sagemaker ];
+then
+	echo "Folder $Folder  exist."
+	rm -rf ../../docker/volumes/minio/bucket/rl-deepracer-pretrained
+	mv ../../docker/volumes/minio/bucket/rl-deepracer-sagemaker ../../docker/volumes/minio/bucket/rl-deepracer-pretrained
+	echo "Done."
 
-rm -rf ../../docker/volumes/minio/bucket/rl-deepracer-pretrained
-mv ../../docker/volumes/minio/bucket/rl-deepracer-sagemaker ../../docker/volumes/minio/bucket/rl-deepracer-pretrained
+else
+	echo "Folder $Folder does not exist" 
+fi


### PR DESCRIPTION
By running the set-last-run-to-pretrained.sh twice, The `rl-deepracer-pretrained` folder will be removed as well as losing the training files if you didn't take a checkpoint.
This code checks for the ` rl-deepracer-sagemaker` before deleting the `rl-deepracer-pretrained` **to prevent the training data from being accidentally removed**.