### PR TITLE
Add Proxy Configration to Docker Build

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -29,12 +29,9 @@ do
     IFS='=' read -ra part <<< "$arg"
     if [ "${part[0]}" == "--http_proxy" ] || [ "${part[0]}" == "--https_proxy" ] || [ "${part[0]}" == "--no_proxy" ]; then
         var=${part[0]:2}=${part[1]}
-        envs=$'\n'"${var}${envs}"
         args="${args} --build-arg ${var}"
     fi
 done
-
-echo -e "$envs" >> ./docker/.env
 
 # build rl-coach image with latest code from crr0004's repo
 docker build ${args} -f ./docker/dockerfiles/rl_coach/Dockerfile -t aschu/rl_coach deepracer/


### PR DESCRIPTION
Added args to init.sh command to set --http_proxy, --https_proxy, and --no_proxy for building the rl_coach image behind a corporate proxy.

Example command:
./init.sh --https_proxy=http://user:pass@proxy.corp:8080 --http_proxy=http://user:pass@proxy.corp:8080 --no_proxy=127.0.0.1,localhost,.corp