### PR TITLE
CLI Training and Evaluation

### DIFF
--- a/scripts/evaluation/start.sh
+++ b/scripts/evaluation/start.sh
@@ -11,8 +11,16 @@ echo 'waiting for containers to start up...'
 #sleep for 20 seconds to allow the containers to start
 sleep 15
 
-echo 'attempting to pull up sagemaker logs...'
-gnome-terminal -x sh -c "!!; docker logs -f $(docker ps | awk ' /sagemaker/ { print $1 }')"
+if xhost >& /dev/null;
+then
+  echo "Display exists, using gnome-terminal for logs and starting vncviewer."
 
-echo 'attempting to open vnc viewer...'
-gnome-terminal -x sh -c "!!; vncviewer localhost:8080"
+  echo 'attempting to pull up sagemaker logs...'
+  gnome-terminal -x sh -c "!!; docker logs -f $(docker ps | awk ' /sagemaker/ { print $1 }')"
+
+  echo 'attempting to open vnc viewer...'
+  gnome-terminal -x sh -c "!!; vncviewer localhost:8080"
+else
+  echo "No display. Falling back to CLI mode."
+  docker logs -f $(docker ps | awk ' /sagemaker/ { print $1 }')
+fi

--- a/scripts/training/start.sh
+++ b/scripts/training/start.sh
@@ -8,24 +8,31 @@ echo 'waiting for containers to start up...'
 #sleep for 20 seconds to allow the containers to start
 sleep 15
 
-if ! [ -x "$(command -v gnome-terminal)" ]; 
+if xhost >& /dev/null;
 then
-  echo 'Error: skip showing sagemaker logs because gnome-terminal is not installed.  This is normal if you are on a different OS to Ubuntu.'
-else	
-  echo 'attempting to pull up sagemaker logs...'
-  gnome-terminal -x sh -c "!!; docker logs -f $(docker ps | awk ' /sagemaker/ { print $1 }')"
-fi
-
-if ! [ -x "$(command -v gnome-terminal)" ]; 
-then
-  if ! [ -x "$(command -v vncviewer)" ]; 
+  echo "Display exists, using gnome-terminal for logs and starting vncviewer."
+  if ! [ -x "$(command -v gnome-terminal)" ]; 
   then
-    echo 'Error: vncviewer is not present on the PATH.  Make sure you install it and add it to the PATH.'
+    echo 'Error: skip showing sagemaker logs because gnome-terminal is not installed.  This is normal if you are on a different OS to Ubuntu.'
+  else	
+    echo 'attempting to pull up sagemaker logs...'
+    gnome-terminal -x sh -c "!!; docker logs -f $(docker ps | awk ' /sagemaker/ { print $1 }')"
+  fi
+
+  if ! [ -x "$(command -v gnome-terminal)" ]; 
+  then
+    if ! [ -x "$(command -v vncviewer)" ]; 
+    then
+      echo 'Error: vncviewer is not present on the PATH.  Make sure you install it and add it to the PATH.'
+    else	
+      echo 'attempting to open vnc viewer...'
+      vncviewer localhost:8080
+    fi
   else	
     echo 'attempting to open vnc viewer...'
-    vncviewer localhost:8080
+    gnome-terminal -x sh -c "!!; vncviewer localhost:8080"
   fi
-else	
-  echo 'attempting to open vnc viewer...'
-  gnome-terminal -x sh -c "!!; vncviewer localhost:8080"
+else
+  echo "No display. Falling back to CLI mode."
+  docker logs -f $(docker ps | awk ' /sagemaker/ { print $1 }')
 fi


### PR DESCRIPTION
Added additional check to ./scripts/training/start.sh and ./scripts/evaluation/start.sh to avoid errors when using a machine that has ubuntu desktop installed but training is executed via ssh.